### PR TITLE
Merge feature/add-optional-explicit-start-to-template-tags

### DIFF
--- a/src/AC-LuaServer/Core/Output/Template/TemplateNodeTree/TagFinder/TagFinder.lua
+++ b/src/AC-LuaServer/Core/Output/Template/TemplateNodeTree/TagFinder/TagFinder.lua
@@ -24,10 +24,10 @@ local TagFinder = Object:extend()
 TagFinder.tagPatterns = {
   { tagName = "config", pattern = "##+%[ *CONFIG *]#*;" },
   { tagName = "end-config", pattern = "##+%[ *ENDCONFIG *]#*;" },
-  { tagName = "custom-field", pattern = "%-%-+%[ *FIELD *]%-*;" },
-  { tagName = "end-custom-field", pattern = "%-%-+%[ *ENDFIELD *]%-*;" },
-  { tagName = "row", pattern = "__+;" },
-  { tagName = "row-field", pattern = "%-%-+;" }
+  { tagName = "custom-field", pattern = "|?%-%-+%[ *FIELD *]%-*;" },
+  { tagName = "end-custom-field", pattern = "|?%-%-+%[ *ENDFIELD *]%-*;" },
+  { tagName = "row", pattern = "|?__+;" },
+  { tagName = "row-field", pattern = "|?%-%-+;" }
 }
 
 


### PR DESCRIPTION
Problem was that player names in !maptop could end with `-`.
In that case the trailing `-` are seen as part of the `-------;` column separator tag and would thus not appear in the output message.